### PR TITLE
Fix: validateAndTrimData 함수에서 data trim 시 최근 데이터 기준으로 자르기 #46

### DIFF
--- a/src/utils/validateAndTrimData.ts
+++ b/src/utils/validateAndTrimData.ts
@@ -22,8 +22,8 @@ const validateAndTrimData = (data: string): { status: 'ok' | 'error'; data?: str
   };
 
   const trimData = (data: string): string => {
-    // 데이터 최대 토큰 수만큼 자르기
-    const trimedTokens = encode(data).slice(0, MAX);
+    // 최근 데이터 기준으로, 최대 토큰 수만큼 자르기
+    const trimedTokens = encode(data).slice(-MAX);
     return decode(trimedTokens);
   };
 


### PR DESCRIPTION
closes: #46

### 📝 개요

- 최근 데이터를 최대 토큰 수만큼 자르도록 명세했는데, 적용되지 않아 해당 내용을 수정하였습니다.

### 💽 작업 사항

- trimData 함수 변경