### PR TITLE
[Feat] 로그인, 회원가입 기능 보완 | coin 항목 추가, 소셜 로그인 DB 저장과 자동로그인 기능 추가 

### DIFF
--- a/auth.d.ts
+++ b/auth.d.ts
@@ -2,13 +2,13 @@ export declare module '@auth/core/types' {
   interface User {
     type: string;
     loginType: string;
-    coin: string;
+    coin: number;
     accessToken: string;
     refreshToken: string;
   }
 
   interface Session {
-    coin: string;
+    coin: number;
     accessToken: string;
     refreshToken: string;
   }
@@ -16,7 +16,7 @@ export declare module '@auth/core/types' {
 
 export declare module '@auth/core/jwt' {
   interface JWT {
-    coin: string;
+    coin: number;
     accessToken: string;
     refreshToken: string;
   }

--- a/auth.d.ts
+++ b/auth.d.ts
@@ -2,11 +2,13 @@ export declare module '@auth/core/types' {
   interface User {
     type: string;
     loginType: string;
+    coin: string;
     accessToken: string;
     refreshToken: string;
   }
 
   interface Session {
+    coin: string;
     accessToken: string;
     refreshToken: string;
   }
@@ -14,6 +16,7 @@ export declare module '@auth/core/types' {
 
 export declare module '@auth/core/jwt' {
   interface JWT {
+    coin: string;
     accessToken: string;
     refreshToken: string;
   }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,7 +1,7 @@
 import NextAuth, { User } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
+
 import KakaoProvider from 'next-auth/providers/kakao';
-import NaverProvider from 'next-auth/providers/naver';
 import GoogleProvider from 'next-auth/providers/google';
 
 const API_SERVER = process.env.NEXT_PUBLIC_API_SERVER;
@@ -54,13 +54,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       },
     }),
 
-    NaverProvider({
-      clientId: process.env.KAKAO_CLIENT_ID ?? '',
-      clientSecret: process.env.KAKAO_CLIENT_SECRET ?? '',
-    }),
+    // GitHubProvider({
+    //   clientId: process.env.KAKAO_CLIENT_ID ?? '',
+    //   clientSecret: process.env.KAKAO_CLIENT_SECRET ?? '',
+    // }),
     KakaoProvider({
-      clientId: process.env.KAKAO_CLIENT_ID ?? '',
-      clientSecret: process.env.KAKAO_CLIENT_SECRET ?? '',
+      clientId: process.env.AUTH_KAKAO_ID ?? '',
+      clientSecret: process.env.AUTH_KAKAO_SECRET ?? '',
     }),
     GoogleProvider({
       clientId: process.env.AUTH_GOOGLE_ID ?? '',

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -29,7 +29,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           const resJson = await response.json();
 
           if (resJson.ok) {
-            console.log('🪪 user정보 ->', resJson.item);
+            console.log('🪪 user정보->', resJson.item);
             const user = resJson.item;
 
             // 유저 정보와 토큰 NextAuth 세션에 저장
@@ -38,6 +38,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               name: user.name,
               email: user.email,
               type: user.type,
+              coin: user.extra.coin,
               loginType: user.loginType,
               accessToken: user.token?.accessToken,
               refreshToken: user.token?.refreshToken,
@@ -79,7 +80,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   },
   callbacks: {
     async signIn({ user }) {
-      console.log('signIn.user', user);
+      console.log('⭐️로그인 callback user', user);
       return true;
     },
 
@@ -90,6 +91,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       if (user) {
         token.id = user.id;
         token.type = user.type;
+        token.coin = user.coin; //코인 정보 추가
         token.accessToken = user.accessToken;
         token.refreshToken = user.refreshToken;
       }
@@ -100,6 +102,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     async session({ session, token }) {
       session.user.id = token.id as string;
       session.user.type = token.type as string;
+      session.user.coin = token.coin; // 코인 정보 추가
       session.accessToken = token.accessToken;
       session.refreshToken = token.refreshToken;
       return session;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -80,8 +80,17 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     signIn: '/login',
   },
   callbacks: {
-    async signIn({ user }) {
+    // TODO - 소셜 로그인 후 서버에 사용자 정보 저장 구현
+    async signIn({ user, account, profile }) {
       console.log('⭐️로그인 callback user', user);
+      console.log('⭐️Account:', account); // 로그인한 계정 정보
+
+      // 소셜 로그인 - callback을 통해 token 정보 추가
+      if (account?.type !== 'credentials') {
+        user.accessToken = account?.access_token || '';
+        user.refreshToken = account?.refresh_token || '';
+      }
+
       return true;
     },
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import NextAuth, { User } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 
+import GithubProvider from 'next-auth/providers/github';
 import KakaoProvider from 'next-auth/providers/kakao';
 import GoogleProvider from 'next-auth/providers/google';
 
@@ -54,10 +55,10 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       },
     }),
 
-    // GitHubProvider({
-    //   clientId: process.env.KAKAO_CLIENT_ID ?? '',
-    //   clientSecret: process.env.KAKAO_CLIENT_SECRET ?? '',
-    // }),
+    GithubProvider({
+      clientId: process.env.AUTH_GITHUB_ID ?? '',
+      clientSecret: process.env.AUTH_GITHUB_SECRET ?? '',
+    }),
     KakaoProvider({
       clientId: process.env.AUTH_KAKAO_ID ?? '',
       clientSecret: process.env.AUTH_KAKAO_SECRET ?? '',

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -4,7 +4,7 @@ import CredentialsProvider from 'next-auth/providers/credentials';
 import GithubProvider from 'next-auth/providers/github';
 import KakaoProvider from 'next-auth/providers/kakao';
 import GoogleProvider from 'next-auth/providers/google';
-import { OAuthUser, SignupResponsType, UserType } from './types';
+import { OAuthUser, SignupResponsType } from './types';
 import { loginOAuth, signupWithOAuth } from './serverActions/userActions';
 
 const API_SERVER = process.env.NEXT_PUBLIC_API_SERVER;
@@ -100,9 +100,9 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             const newUser: OAuthUser = {
               type: 'user',
               loginType: account.provider,
-              name: user.name || '',
-              email: user.email || '',
-              image: user.image || '',
+              name: user.name!,
+              email: user.email!,
+              image: user.image!,
               extra: { ...profile, providerAccountId: account.providerAccountId, coin: 0 },
             };
 
@@ -125,7 +125,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           }
 
           user.id = String(userInfo?._id);
-          user.type = userInfo?.type || '';
+          user.type = userInfo?.type!;
           user.accessToken = userInfo?.token!.accessToken as string;
           user.refreshToken = userInfo?.token!.refreshToken as string;
           user.coin = userInfo?.extra!.coin;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -86,13 +86,12 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       console.log('callbacks.signIn', user, account, profile);
       switch (account?.provider) {
         case 'credentials':
-          console.log('id/pwd 로그인', user);
+          console.log('🪪 id/pwd 로그인', user);
           break;
         case 'google':
         case 'github':
-          // FIXME - kakao는 비즈앱 전환해야 이메일 받을 수 있어서 DB 저장 이슈 있음
-          // case 'kakao'
-          console.log('OAuth 로그인', user);
+        case 'kakao':
+          console.log('🪪 OAuth 로그인', user);
 
           // DB에서 id를 조회해서 있으면 로그인 처리를 없으면 자동 회원 가입 후 로그인 처리
           let userInfo: SignupResponsType | null = null;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -104,7 +104,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
               name: user.name || '',
               email: user.email || '',
               image: user.image || '',
-              extra: { ...profile, providerAccountId: account.providerAccountId, coin: '0' },
+              extra: { ...profile, providerAccountId: account.providerAccountId, coin: 0 },
             };
 
             // 이미 가입된 회원이면 회원가입이 되지 않고 에러를 응답하므로 무시하면 됨

--- a/src/components/Form/LoginForm/LoginForm.tsx
+++ b/src/components/Form/LoginForm/LoginForm.tsx
@@ -90,8 +90,12 @@ function LoginForm() {
         <div className="icons">
           {/* TODO - icon으로 추후 변경 */}
           <button onClick={() => handleSocialLogin('google')}>구글</button>
-          <button type="button">네이버</button>
-          <button type="button">카카오</button>
+          <button type="button" onClick={() => handleSocialLogin('github')}>
+            깃헙
+          </button>
+          <button type="button" onClick={() => handleSocialLogin('kakao')}>
+            카카오
+          </button>
         </div>
       </div>
     </form>

--- a/src/components/Form/LoginForm/LoginForm.tsx
+++ b/src/components/Form/LoginForm/LoginForm.tsx
@@ -93,9 +93,9 @@ function LoginForm() {
           <button type="button" onClick={() => handleSocialLogin('github')}>
             깃헙
           </button>
-          {/* <button type="button" onClick={() => handleSocialLogin('kakao')}>
+          <button type="button" onClick={() => handleSocialLogin('kakao')}>
             카카오
-          </button> */}
+          </button>
         </div>
       </div>
     </form>

--- a/src/components/Form/LoginForm/LoginForm.tsx
+++ b/src/components/Form/LoginForm/LoginForm.tsx
@@ -93,9 +93,9 @@ function LoginForm() {
           <button type="button" onClick={() => handleSocialLogin('github')}>
             깃헙
           </button>
-          <button type="button" onClick={() => handleSocialLogin('kakao')}>
+          {/* <button type="button" onClick={() => handleSocialLogin('kakao')}>
             카카오
-          </button>
+          </button> */}
         </div>
       </div>
     </form>

--- a/src/components/Form/SignupForm/SignupForm.tsx
+++ b/src/components/Form/SignupForm/SignupForm.tsx
@@ -5,9 +5,6 @@ import { SignupFormType } from '@/types';
 import './_SignupForm.scss';
 import { signup } from '@/serverActions/userActions';
 
-const API_SERVER = process.env.NEXT_PUBLIC_API_SERVER;
-const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
-
 function SignupForm() {
   const {
     register,
@@ -39,14 +36,10 @@ function SignupForm() {
       ? errors.passwordConfirm.message
       : undefined;
 
-  // NOTE - 회원가입 구현
-
   const createUser = async (formData: SignupFormType) => {
     formData.type = 'user';
-    // console.log('👼 create User-> ', formData);
     try {
       const resData = await signup(formData);
-      console.log(resData);
     } catch (error) {
       console.error('Error:', error);
     }

--- a/src/components/Form/SignupForm/SignupForm.tsx
+++ b/src/components/Form/SignupForm/SignupForm.tsx
@@ -3,6 +3,7 @@
 import { useForm } from 'react-hook-form';
 import { SignupFormType } from '@/types';
 import './_SignupForm.scss';
+import { signup } from '@/serverActions/userActions';
 
 const API_SERVER = process.env.NEXT_PUBLIC_API_SERVER;
 const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
@@ -42,24 +43,10 @@ function SignupForm() {
 
   const createUser = async (formData: SignupFormType) => {
     formData.type = 'user';
-    console.log('👼 create User-> ', formData);
-
+    // console.log('👼 create User-> ', formData);
     try {
-      const response = await fetch(`${API_SERVER}/users`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'client-id': `${CLIENT_ID}`,
-        },
-        body: JSON.stringify(formData),
-      });
-
-      if (!response.ok) {
-        throw new Error('😞 Network response was not ok');
-      }
-
-      const data = await response.json();
-      console.log(data);
+      const resData = await signup(formData);
+      console.log(resData);
     } catch (error) {
       console.error('Error:', error);
     }

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -1,0 +1,39 @@
+'use client';
+import Link from 'next/link';
+import './_Footer.scss';
+import { IconGitHub, IconInsta, IconMail } from '@/public/image';
+
+export default function Footer() {
+  return (
+    <footer className="footer-container">
+      <h2>Highlightalk</h2>
+      <div className="footer-details">
+        <p>Project Highlightalk | TmuchTalker</p>
+        <dl>
+          <dt>Contact</dt>
+          <dd>Nope... Mail Plz.</dd>
+
+          <dt>Email</dt>
+          <dd>tmuchtalker@gmail.com</dd>
+
+          <dt>Phone</dt>
+          <dd>111-1234-1234</dd>
+        </dl>
+        <address></address>
+        <small>ⓒ TmuchTalker All Rights Reserved.</small>
+      </div>
+
+      <nav className="social-links">
+        <Link href="#">
+          <IconInsta />
+        </Link>
+        <Link href="mailto:tmuchtalker@gmail.com" target="_blank">
+          <IconMail />
+        </Link>
+        <Link href="https://github.com/FRONTENDSCHOOLPLUS2/HighlighTalk" target="_blank">
+          <IconGitHub />
+        </Link>
+      </nav>
+    </footer>
+  );
+}

--- a/src/components/layout/Header/UserProfile/UserProfile.tsx
+++ b/src/components/layout/Header/UserProfile/UserProfile.tsx
@@ -12,6 +12,8 @@ interface UserProfilePropType {
 
 function UserProfile({ userSession }: UserProfilePropType) {
   const router = useRouter();
+  // NOTE - 세션 정보 브라우저 조회용으로 작성
+  console.log('UserProfile_🪪 session', userSession);
 
   return (
     <>

--- a/src/serverActions/userActions.ts
+++ b/src/serverActions/userActions.ts
@@ -1,5 +1,5 @@
 'use server';
-
+// NOTE - 회원가입 Action
 import { SignupFormType } from '@/types';
 
 const SERVER = process.env.NEXT_PUBLIC_API_SERVER;
@@ -11,7 +11,7 @@ export async function signup(data: SignupFormType) {
     name: data.name,
     email: data.email,
     password: data.password,
-    coin: '0',
+    extra: { coin: 0 },
   };
 
   const res = await fetch(`${SERVER}/users`, {
@@ -24,6 +24,6 @@ export async function signup(data: SignupFormType) {
   });
 
   const resJson = await res.json();
-  console.log('💽 userActions/resJson', resJson);
+  console.log('💽 userActions 회원가입 /resJson', resJson);
   return resJson;
 }

--- a/src/serverActions/userActions.ts
+++ b/src/serverActions/userActions.ts
@@ -11,6 +11,7 @@ export async function signup(data: SignupFormType) {
     name: data.name,
     email: data.email,
     password: data.password,
+    coin: '0',
   };
 
   const res = await fetch(`${SERVER}/users`, {

--- a/src/serverActions/userActions.ts
+++ b/src/serverActions/userActions.ts
@@ -1,6 +1,6 @@
 'use server';
 // NOTE - 회원가입 Action
-import { SignupFormType } from '@/types';
+import { OAuthUser, SignupFormType } from '@/types';
 
 const SERVER = process.env.NEXT_PUBLIC_API_SERVER;
 const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
@@ -26,4 +26,29 @@ export async function signup(data: SignupFormType) {
   const resJson = await res.json();
   console.log('💽 userActions 회원가입 /resJson', resJson);
   return resJson;
+}
+
+export async function signupWithOAuth(user: OAuthUser) {
+  const res = await fetch(`${SERVER}/users/signup/oauth`, {
+    method: 'POST',
+    headers: {
+      'client-id': `${CLIENT_ID}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(user),
+  });
+
+  return res.json();
+}
+
+export async function loginOAuth(providerAccountId: string) {
+  const res = await fetch(`${SERVER}/users/login/with`, {
+    method: 'POST',
+    headers: {
+      'client-id': `${CLIENT_ID}`,
+      'Content-type': 'application/json',
+    },
+    body: JSON.stringify({ providerAccountId }),
+  });
+  return res.json();
 }

--- a/src/serverActions/userActions.ts
+++ b/src/serverActions/userActions.ts
@@ -1,0 +1,28 @@
+'use server';
+
+import { SignupFormType } from '@/types';
+
+const SERVER = process.env.NEXT_PUBLIC_API_SERVER;
+const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
+
+export async function signup(data: SignupFormType) {
+  const userData = {
+    type: data.type || 'user',
+    name: data.name,
+    email: data.email,
+    password: data.password,
+  };
+
+  const res = await fetch(`${SERVER}/users`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'client-id': `${CLIENT_ID}`,
+    },
+    body: JSON.stringify(userData),
+  });
+
+  const resJson = await res.json();
+  console.log('💽 userActions/resJson', resJson);
+  return resJson;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -8,6 +8,7 @@ export interface UserType {
   profile?: string;
   createdAt: string;
   updatedAt: string;
+  coin?: string;
 }
 
 export interface TokenType {
@@ -23,7 +24,10 @@ export interface SignupResponsType extends UserType {
 export interface LoginFormType extends Pick<UserType, 'email'> {
   password: string;
 }
+
+// NOTE - 회원가입 할 때는 extra 데이터에 coin 넣어서 보냄
 export interface SignupFormType extends Pick<UserType, 'type' | 'name' | 'email'> {
   password: string;
   passwordConfirm: string;
+  extra: { coin: string };
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -34,5 +34,5 @@ export interface LoginFormType extends Pick<UserType, 'email'> {
 export interface SignupFormType extends Pick<UserType, 'type' | 'name' | 'email'> {
   password: string;
   passwordConfirm: string;
-  extra: { coin: string };
+  extra: { coin: number };
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -3,13 +3,18 @@ export interface UserType {
   email: string;
   name: string;
   type: 'user';
-  loginType?: 'email'; // 'email' | 'google' | '' 등으로 확장 작성
+  loginType?: 'email' | 'google' | 'kakao' | 'github'; // 'email' | 'google' | '' 등으로 확장 작성
   image?: string;
   profile?: string;
   createdAt: string;
   updatedAt: string;
-  coin?: string;
+  extra?: {
+    [key: string]: any;
+  };
 }
+
+export type OAuthUser = Required<Pick<UserType, 'type' | 'loginType'>> &
+  Partial<Pick<UserType, 'name' | 'email' | 'image' | 'extra'>>;
 
 export interface TokenType {
   id?: string;


### PR DESCRIPTION
closes: #38

### 📝 개요
로그인, 회원가입 관련하여 기능 추가하였습니다.

- coin 항목 추가 
DB 상으로는 user의 extra 항목에 coin 저장되지만 session으로 유저 정보 조회 시에는 유저의 email, name과 같은 depth로 coin 정보가 들어가도록 설계했습니다. (아래 스크린샷 참고) 
- 소셜로그인 깃허브, 카카오 추가 지원 
-   카카오 로그인 가능하나 DB에 올리지 못하는 이슈 있어서 카톡 로그인 버튼 주석으로 막아두었습니다. 
이슈: DB에 올릴 email 정보가 필요한데 비즈앱을 통해 받을 수 있음 현재 email이 undefined임 
비즈앱 전환 후 switch의 case:kakao 부분 주석 풀면 토큰 발급 + DB 업로드 기능 바로 동작할 것 예상 (auth.ts의 FIXME 주석 참고)


### 💽 작업 사항


| **로그인 유형**  | **이미지**                                                   |
|-----------------|----------------------------------------------------------------|
| **Credentials** | ![Credentials 로그인](https://github.com/user-attachments/assets/4c9da226-5a5c-4848-9aad-c0c2395b28b1) |
| **GitHub**      | ![GitHub 로그인](https://github.com/user-attachments/assets/236b7b76-f3fa-445e-8f9e-de01ac201d8e)    |
| **Google**      | ![Google 로그인](https://github.com/user-attachments/assets/36bac7dd-e0dc-458a-9849-ccf83732fdcf)    |
| **Kakao**      | ![Kakao 로그인](https://github.com/user-attachments/assets/5917bf9e-7b6c-4d31-8426-7892ff91001a)    |



DB에 소셜로그인 잘 올라감 -> 

<img width="831" alt="스크린샷 2024-08-16 오후 5 42 16" src="https://github.com/user-attachments/assets/a8c743ac-7a74-4c20-a800-00051304edbe">

# !! 환경변수 파일 수정 사항 있습니다 
(디스코드에 올려두겠습니다) 