### PR TITLE
[Feat] Header 공통 컴포넌트를 구현한다. 

### DIFF
--- a/src/app/(home)/about/page.tsx
+++ b/src/app/(home)/about/page.tsx
@@ -1,0 +1,4 @@
+function AboutPage() {
+  return <div>AboutPage</div>;
+}
+export default AboutPage;

--- a/src/app/(home)/contact/page.tsx
+++ b/src/app/(home)/contact/page.tsx
@@ -1,0 +1,4 @@
+function ContactPage() {
+  return <div>ContactPage</div>;
+}
+export default ContactPage;

--- a/src/app/(user)/[id]/mypage/page.tsx
+++ b/src/app/(user)/[id]/mypage/page.tsx
@@ -1,5 +1,14 @@
+import { signOutWithForm } from '@/serverActions/authAction';
+
 function MyPage({ params }: { params: { id: string } }) {
   console.log(params.id);
-  return <div>마이페이지입니다 user id -{params.id} </div>;
+  return (
+    <div>
+      <form action={signOutWithForm}>
+        <button type="submit">👀로그아웃하기</button>
+      </form>
+      마이페이지입니다 user id -{params.id};
+    </div>
+  );
 }
 export default MyPage;

--- a/src/app/(user)/mypage/page.tsx
+++ b/src/app/(user)/mypage/page.tsx
@@ -1,13 +1,17 @@
+import { auth } from '@/auth';
 import { signOutWithForm } from '@/serverActions/authAction';
 
-function MyPage({ params }: { params: { id: string } }) {
-  console.log(params.id);
+// TODO - MiddelWare 처리
+
+async function MyPage() {
+  const userAuth = await auth();
+  console.log('userAuth', userAuth);
   return (
     <div>
       <form action={signOutWithForm}>
         <button type="submit">👀로그아웃하기</button>
       </form>
-      마이페이지입니다 user id -{params.id};
+      마이페이지입니다 user id {userAuth?.user!.id ?? '하이'}
     </div>
   );
 }

--- a/src/components/Logo/logoFont.ts
+++ b/src/components/Logo/logoFont.ts
@@ -1,9 +1,0 @@
-// poppins
-
-import { Poppins } from 'next/font/google';
-
-export const logoFont = Poppins({
-  weight: '700',
-  subsets: ['latin'],
-  display: 'swap',
-});

--- a/src/components/Logo/logoFont.ts
+++ b/src/components/Logo/logoFont.ts
@@ -1,0 +1,9 @@
+// poppins
+
+import { Poppins } from 'next/font/google';
+
+export const logoFont = Poppins({
+  weight: '700',
+  subsets: ['latin'],
+  display: 'swap',
+});

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -11,7 +11,7 @@ async function Header() {
     <header className={poppinsFont.className}>
       <div className="HeaderLayout">
         {/* 사이트 로고 및 제목 */}
-        <div>
+        <div className="logo">
           <Link href="/" className="logo-link">
             highlightalk
           </Link>

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,19 +1,22 @@
 import Link from 'next/link';
-import './Header.scss';
+import './_Header.scss';
 import { auth } from '@/auth';
+
 import UserProfile from './UserProfile/UserProfile';
 
 async function Header() {
   const session = await auth();
+  console.log('👀세션 정보 ->', session);
+
   return (
     <header>
       <div className="HeaderLayout">
         {/* 사이트 로고 및 제목 */}
-        <div className="logo">
+        <h1 className="logo">
           <Link href="/" className="logo-link">
             Highlightalk
           </Link>
-        </div>
+        </h1>
 
         {/* 네비게이션 메뉴 */}
         <nav className="header-nav">

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,37 +1,24 @@
 import Link from 'next/link';
 import './_Header.scss';
 import { auth } from '@/auth';
-
 import UserProfile from './UserProfile/UserProfile';
+import { poppinsFont } from '@/utils/font';
+import NavBar from './NavBar/NavBar';
 
 async function Header() {
   const session = await auth();
-  console.log('👀세션 정보 ->', session);
-
   return (
-    <header>
+    <header className={poppinsFont.className}>
       <div className="HeaderLayout">
         {/* 사이트 로고 및 제목 */}
-        <h1 className="logo">
+        <div>
           <Link href="/" className="logo-link">
-            Highlightalk
+            highlightalk
           </Link>
-        </h1>
+        </div>
 
         {/* 네비게이션 메뉴 */}
-        <nav className="header-nav">
-          <ul>
-            <li>
-              <Link href="/about">about</Link>
-            </li>
-            <li>
-              <Link href="/">contact</Link>
-            </li>
-            <li>
-              <Link href="/">Posts</Link>
-            </li>
-          </ul>
-        </nav>
+        <NavBar />
         <UserProfile userSession={session} />
       </div>
     </header>

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -11,11 +11,11 @@ async function Header() {
     <header className={poppinsFont.className}>
       <div className="HeaderLayout">
         {/* 사이트 로고 및 제목 */}
-        <div className="logo">
+        <h1 className="logo">
           <Link href="/" className="logo-link">
             highlightalk
           </Link>
-        </div>
+        </h1>
 
         {/* 네비게이션 메뉴 */}
         <NavBar />

--- a/src/components/layout/Header/NavBar/NavBar.tsx
+++ b/src/components/layout/Header/NavBar/NavBar.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useRouter, usePathname } from 'next/navigation';
+import './_NavBar.scss';
+
+function NavBar() {
+  const pathname = usePathname();
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const navItems = [
+    { path: '/', label: 'home' },
+    { path: '/about', label: 'about' },
+    { path: '/contact', label: 'contact' },
+    { path: '/posts', label: 'Posts' },
+  ];
+
+  return (
+    <nav className="header-nav">
+      <ul>
+        {navItems.map((item, index) => (
+          <li
+            key={item.path}
+            className={pathname === item.path ? 'active' : ''}
+            onClick={() => setActiveIndex(index)}
+          >
+            <Link href={item.path}>{item.label}</Link>
+          </li>
+        ))}
+        <div
+          className="active-box"
+          style={{
+            left: `${activeIndex * (100 / navItems.length)}%`,
+            width: `${100 / navItems.length}%`,
+          }}
+        />
+      </ul>
+    </nav>
+  );
+}
+export default NavBar;

--- a/src/components/layout/Header/NavBar/NavBar.tsx
+++ b/src/components/layout/Header/NavBar/NavBar.tsx
@@ -1,20 +1,27 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useRouter, usePathname } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import './_NavBar.scss';
+
+const navItems = [
+  { path: '/', label: 'home' },
+  { path: '/about', label: 'about' },
+  { path: '/contact', label: 'contact' },
+  { path: '/posts', label: 'posts' },
+];
 
 function NavBar() {
   const pathname = usePathname();
-  const [activeIndex, setActiveIndex] = useState(0);
+  const indexInit = navItems.findIndex((item) => item.path === pathname);
+  const [activeIndex, setActiveIndex] = useState(indexInit);
 
-  const navItems = [
-    { path: '/', label: 'home' },
-    { path: '/about', label: 'about' },
-    { path: '/contact', label: 'contact' },
-    { path: '/posts', label: 'Posts' },
-  ];
+  useEffect(() => {
+    activeIndex === -1 ? setActiveIndex(navItems.length + 1) : setActiveIndex(indexInit);
+  }, [pathname]);
+
+  console.log(indexInit);
 
   return (
     <nav className="header-nav">
@@ -31,8 +38,10 @@ function NavBar() {
         <div
           className="active-box"
           style={{
-            left: `${activeIndex * (100 / navItems.length)}%`,
-            width: `${100 / navItems.length}%`,
+            opacity: activeIndex === -1 ? '0' : '1',
+            left: activeIndex !== -1 ? `${activeIndex * (100 / navItems.length)}%` : 'auto',
+            width: activeIndex !== -1 ? `${100 / navItems.length}%` : '0',
+            transition: 'left 0.3s ease, width 0.3s ease',
           }}
         />
       </ul>

--- a/src/components/layout/Header/NavBar/_NavBar.scss
+++ b/src/components/layout/Header/NavBar/_NavBar.scss
@@ -1,21 +1,40 @@
 .header-nav {
   ul {
+    position: relative;
     display: flex;
     list-style: none;
+    font-size: 1.6rem;
   }
 
   li {
     margin: 0 auto;
-    padding: 1rem 2.4rem;
+    width: 10rem;
+    padding: 1rem 0;
+    z-index: 20;
+    text-align: center;
   }
 
   a {
     text-decoration: none;
     color: #000;
-    transition: color 0.3s;
+  }
 
-    &:hover {
-      color: #007bff;
-    }
+  // 이동하는 active 박스 설정
+  .active-box {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 0;
+    height: 100%;
+    background-color: #f6f6f6;
+    border-radius: 10rem;
+    z-index: 10; // active 박스는 li 요소 뒤에 배치
+    transition: all 0.3s ease;
+  }
+
+  li.active ~ .active-box {
+    width: calc(100% + 4rem); // padding을 고려하여 너비 조정
+    transform: translateX(calc(var(--index) * 100%)); // 각 li의 위치에 맞게 이동
   }
 }

--- a/src/components/layout/Header/NavBar/_NavBar.scss
+++ b/src/components/layout/Header/NavBar/_NavBar.scss
@@ -1,3 +1,5 @@
+@import '@/styles/variable.scss';
+
 .header-nav {
   position: absolute;
   left: 50%;
@@ -24,7 +26,6 @@
     color: #000;
   }
 
-  // 이동하는 active 박스 설정
   .active-box {
     position: absolute;
     top: 0;
@@ -32,15 +33,15 @@
     left: 0;
     width: 0;
     height: 100%;
-    background-color: #f6f6f6;
+    background-color: lighten($color-gray-2, 20%);
     border-radius: 10rem;
-    z-index: 10; // active 박스는 li 요소 뒤에 배치
+    z-index: 10;
     transition: all 0.3s ease;
   }
 
   li.active ~ .active-box {
-    width: calc(100% + 4rem); // padding을 고려하여 너비 조정
-    transform: translateX(calc(var(--index) * 100%)); // 각 li의 위치에 맞게 이동
+    width: calc(100% + 4rem);
+    transform: translateX(calc(var(--index) * 100%));
   }
 
   @media (min-width: 768px) and (max-width: 1023px) {

--- a/src/components/layout/Header/NavBar/_NavBar.scss
+++ b/src/components/layout/Header/NavBar/_NavBar.scss
@@ -1,0 +1,21 @@
+.header-nav {
+  ul {
+    display: flex;
+    list-style: none;
+  }
+
+  li {
+    margin: 0 auto;
+    padding: 1rem 2.4rem;
+  }
+
+  a {
+    text-decoration: none;
+    color: #000;
+    transition: color 0.3s;
+
+    &:hover {
+      color: #007bff;
+    }
+  }
+}

--- a/src/components/layout/Header/NavBar/_NavBar.scss
+++ b/src/components/layout/Header/NavBar/_NavBar.scss
@@ -1,4 +1,9 @@
 .header-nav {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  overflow: hidden;
+
   ul {
     position: relative;
     display: flex;
@@ -36,5 +41,8 @@
   li.active ~ .active-box {
     width: calc(100% + 4rem); // padding을 고려하여 너비 조정
     transform: translateX(calc(var(--index) * 100%)); // 각 li의 위치에 맞게 이동
+  }
+
+  @media (min-width: 768px) and (max-width: 1023px) {
   }
 }

--- a/src/components/layout/Header/UserProfile/UserProfile.tsx
+++ b/src/components/layout/Header/UserProfile/UserProfile.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/navigation';
 import { Session } from 'next-auth';
 import './_UserProfile.scss';
 
-import { signOutWithForm } from '@/serverActions/authAction';
 import { IconProfile } from '@public/image';
 
 interface UserProfilePropType {
@@ -16,25 +15,31 @@ function UserProfile({ userSession }: UserProfilePropType) {
   // NOTE - 세션 정보 브라우저 조회용으로 작성
   console.log('UserProfile_🪪 session', userSession);
 
+  console.log('UserProfile / session', userSession);
+
+  const userName = userSession?.user?.name;
+
   return (
     <>
       <div className="user-profile-container">
         {userSession?.user ? (
           <>
-            <form action={signOutWithForm}>
-              <button type="submit">👀로그아웃(임시)</button>
-            </form>
-            <button type="button" onClick={() => router.push(`/${userSession?.user?.id}/mypage`)}>
-              <p>{userSession?.user?.name}</p>
+            <div
+              onClick={() => router.push(`/${userSession?.user?.id}/mypage`)}
+              className="profile-button"
+            >
+              <p>
+                안녕하세요, <strong className="user-name">{userName}</strong> 님!
+              </p>
               <IconProfile />
-            </button>
+            </div>
           </>
         ) : (
           <>
-            <button type="button" onClick={() => router.push('/login')}>
+            <div onClick={() => router.push('/login')} className="profile-button">
               <p>로그인 후 이용해주세요</p>
               <IconProfile />
-            </button>
+            </div>
           </>
         )}
       </div>

--- a/src/components/layout/Header/UserProfile/UserProfile.tsx
+++ b/src/components/layout/Header/UserProfile/UserProfile.tsx
@@ -29,8 +29,16 @@ function UserProfile({ userSession }: UserProfilePropType) {
               className="profile-button"
             >
               <p>
-                안녕하세요, <strong className="user-name">{userName}</strong> 님!
+                <span>안녕하세요,&nbsp;</span>
+                <strong className="user-name">{userName}</strong>
+                <span>님!</span>
               </p>
+              {/* <p>
+                <span>안녕하세요,&nbsp;</span>
+                <strong className="user-name">유저이름이길어</strong>
+                <span>님!</span>
+              </p> */}
+
               <IconProfile />
             </div>
           </>

--- a/src/components/layout/Header/UserProfile/UserProfile.tsx
+++ b/src/components/layout/Header/UserProfile/UserProfile.tsx
@@ -24,21 +24,12 @@ function UserProfile({ userSession }: UserProfilePropType) {
       <div className="user-profile-container">
         {userSession?.user ? (
           <>
-            <div
-              onClick={() => router.push(`/${userSession?.user?.id}/mypage`)}
-              className="profile-button"
-            >
+            <div onClick={() => router.push(`/mypage`)} className="profile-button">
               <p>
                 <span>안녕하세요,&nbsp;</span>
                 <strong className="user-name">{userName}</strong>
                 <span>님!</span>
               </p>
-              {/* <p>
-                <span>안녕하세요,&nbsp;</span>
-                <strong className="user-name">유저이름이길어</strong>
-                <span>님!</span>
-              </p> */}
-
               <IconProfile />
             </div>
           </>

--- a/src/components/layout/Header/UserProfile/UserProfile.tsx
+++ b/src/components/layout/Header/UserProfile/UserProfile.tsx
@@ -3,8 +3,9 @@
 import { useRouter } from 'next/navigation';
 import { Session } from 'next-auth';
 import './_UserProfile.scss';
-import { IconProfile } from '../../../../../public/image';
+
 import { signOutWithForm } from '@/serverActions/authAction';
+import { IconProfile } from '@public/image';
 
 interface UserProfilePropType {
   userSession: Session | null;

--- a/src/components/layout/Header/UserProfile/_UserProfile.scss
+++ b/src/components/layout/Header/UserProfile/_UserProfile.scss
@@ -1,17 +1,37 @@
-// TODO - Header 스타일 작업시 함께 작업
+@use '@/styles/mixins/flex' as mixins;
+@import '@/styles/variable.scss';
+
 .user-profile-container {
   display: flex;
   font-size: 1.4rem;
+  flex-shrink: 1;
 
   .profile-button {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    @include mixins.flexCenter;
+
     gap: 1rem;
     cursor: pointer;
+
+    p {
+      display: flex;
+      align-items: center;
+    }
   }
 
   .user-name {
-    color: #648ff7;
+    display: inline-block;
+    text-align: center;
+    vertical-align: bottom;
+    color: $color-blue-2;
+    max-width: 10rem; // NOTE - 이름 영역 고정값, 한글 기준 8자 수용
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  @media (min-width: 768px) and (max-width: 1023px) {
+    // FIXME - 태블릿 화면 - Nav + Profile 햄버거 메뉴 처리하기
+    background-color: tomato;
+    font-size: 1.2rem;
   }
 }

--- a/src/components/layout/Header/UserProfile/_UserProfile.scss
+++ b/src/components/layout/Header/UserProfile/_UserProfile.scss
@@ -1,6 +1,17 @@
 // TODO - Header 스타일 작업시 함께 작업
-
 .user-profile-container {
   display: flex;
-  font-size: 1.2rem;
+  font-size: 1.4rem;
+
+  .profile-button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    cursor: pointer;
+  }
+
+  .user-name {
+    color: #648ff7;
+  }
 }

--- a/src/components/layout/Header/_Header.scss
+++ b/src/components/layout/Header/_Header.scss
@@ -6,7 +6,7 @@
   justify-content: space-between;
   align-items: center;
   // box-shadow: inset 0px 0px 20px blue;
-  // margin-bottom: 18rem;
+  margin-bottom: 10rem;
   // box-shadow: inset 0px 0px 20px blue;
 
   .logo-link {

--- a/src/components/layout/Header/_Header.scss
+++ b/src/components/layout/Header/_Header.scss
@@ -1,13 +1,10 @@
-// Header.scss
-
 .HeaderLayout {
   display: flex;
   font-size: 1.8rem;
   justify-content: space-between;
   align-items: center;
-  // box-shadow: inset 0px 0px 20px blue;
   margin-bottom: 10rem;
-  // box-shadow: inset 0px 0px 20px blue;
+  position: relative;
 
   .logo-link {
     text-decoration: none; // 밑줄 제거
@@ -15,6 +12,7 @@
   }
 
   .logo {
+    flex-shrink: 0;
     font-weight: bold;
   }
 }

--- a/src/components/layout/Header/_Header.scss
+++ b/src/components/layout/Header/_Header.scss
@@ -17,24 +17,4 @@
   .logo {
     font-weight: bold;
   }
-
-  .header-nav ul {
-    display: flex;
-    list-style: none;
-  }
-
-  .header-nav li {
-    margin: 0 auto;
-    padding: 1rem 2.4rem;
-  }
-
-  .header-nav a {
-    text-decoration: none;
-    color: #000;
-    transition: color 0.3s;
-  }
-
-  .header-nav a:hover {
-    color: #007bff;
-  }
 }

--- a/src/utils/font.ts
+++ b/src/utils/font.ts
@@ -1,0 +1,9 @@
+// poppins
+
+import { Poppins } from 'next/font/google';
+
+export const poppinsFont = Poppins({
+  weight: '700',
+  subsets: ['latin'],
+  display: 'swap',
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@public/*": ["./public/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
closes: #70

### 📝 개요
<img width="600" alt="스크린샷 2024-08-17 오전 12 25 28" src="https://github.com/user-attachments/assets/06065f1c-28c7-48cd-9012-61f0e76d5836">



https://github.com/user-attachments/assets/938f7801-e138-427f-8c75-c199d848af96


 Header 공통 컴포넌트 구현 

### 💽 작업 사항
- next/font/google 이용해 poppins 폰트 logo에 적용 (`utils/font.ts`) 
- header 마진 줄였습니다 (10rem) 
- tsconfig에 @public 추가하여 이미지 파일 import 할때도 절대경로 이용할 수 있도록 추가하였습니다.
- header NavBar 컴포넌트 분리, active 애니메이션 작업 
- NavBar에 home이 있는 것이 사용할 때 자연스러울 것 같아 추가하였습니다. 

부족한 부분 
- 1. 아직 Coin 관련 부분이 merge되지 않았기 때문에 유저의 coin을 표시하는 UI 없음 
- 2. nav바 상의 페이지가 아닌 다른 페이지들로 이동하면 페이지 이동 중 덜컹거림 있는데 1번 이슈 해결할 때 함께 해결하면 될 것 같습니다 ( -> 동영상 6초 부분) 
-  원인 분석해보니까 스크롤 생김 유무 ^‿◠.... `common.css` body 부분에 `overflow-y: scroll;` 추가하면 내용물 길이와 상관 없이 균일하게 동작합니다 여러분들 주무실 것 같으니 내일 여쭤보고 커밋 추가해야겠어요 