### PR TITLE
[Fix] 결과 페이지 스타일링 변경 #52

### DIFF
--- a/src/app/(tests)/freetest/[id]/_FreeTestResultPage.scss
+++ b/src/app/(tests)/freetest/[id]/_FreeTestResultPage.scss
@@ -2,10 +2,20 @@
 @import '@/styles/mixins/flex.scss';
 
 .result {
-  position: relative;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   overflow: hidden auto;
 
+  & > :first-child {
+    padding-top: 11rem;
+  }
+
   & > section {
+    position: relative;
+    padding: 3rem 12rem;
     scroll-margin: 6rem;
     scroll-snap-align: start;
     min-height: 90svh;

--- a/src/app/(tests)/freetest/[id]/components/MbtiSection/MbtiSection.tsx
+++ b/src/app/(tests)/freetest/[id]/components/MbtiSection/MbtiSection.tsx
@@ -1,19 +1,128 @@
-// NOTE 우중님 추후 개발 예정
-import './_MbtiSection.scss';
+'use client';
 
-function MbtiSection({ data }) {
+import './_MbtiSection.scss';
+import Image from 'next/image';
+
+import { EffectCoverflow, Pagination } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { getImageSrc } from '@/utils/getImageSrc';
+
+interface Ability {
+  energy: number;
+  social: number;
+  intelligence: number;
+}
+
+interface MbtiAnalysisItem {
+  names: string;
+  reason: string;
+  item: string;
+  value: string;
+  etc: string[];
+  ability: Ability[];
+}
+
+interface MbtiSectionPropType {
+  data: {
+    mbti: {
+      analysis: MbtiAnalysisItem[];
+    };
+  };
+}
+
+function MbtiSection({ data }: MbtiSectionPropType) {
+  const { analysis = [] } = data.mbti || [];
+  console.log(analysis);
+
   return (
     <section className="mbti">
       <h3 className="heading-3">MBTI</h3>
       <p className="heading-desc">우리 대화방 참여자들의 MBTI 예측</p>
-      <ol className="mbti-list">
+
+      <div className="Mbti-cover">
+        <Swiper
+          effect={'coverflow'}
+          grabCursor={true}
+          centeredSlides={true}
+          slidesPerView={'auto'}
+          coverflowEffect={{
+            stretch: 0,
+            depth: 100,
+            modifier: 1,
+            slideShadows: true,
+          }}
+          loop={true}
+          pagination={{
+            clickable: true, // 클릭 가능하도록 설정
+            renderBullet: (index, className) => `<span class="${className}">${index + 1}</span>`,
+          }}
+          modules={[EffectCoverflow, Pagination]}
+          breakpoints={{
+            976: {
+              slidesPerView: 2.5,
+            },
+          }}
+        >
+          {analysis.map((item, index) => (
+            <SwiperSlide key={index}>
+              <div>
+                <div className="card-header">
+                  <h3>{item.value}</h3>
+                  <h3>{item.names}</h3>
+                  <div className="titles">
+                    <p>{item.etc[0]}</p>
+                    <p>{item.etc[1]}</p>
+                  </div>
+                </div>
+                <div className="card-img">
+                  <Image
+                    priority
+                    src={getImageSrc(item.value)} // MBTI 값에 따른 이미지 경로
+                    width={200}
+                    height={200}
+                    alt="person"
+                  />
+                </div>
+                <p className="mbti-reason">{item.reason}</p>
+                <div className="progress-container">
+                  {item.ability.map((ab, idx) => (
+                    <div key={idx} className="progress-content">
+                      <p>에너지</p>
+                      <div className="progress-bar-wrapper">
+                        <div className="progress-bar" style={{ width: `${ab.energy * 10}%` }}>
+                          <div className="progress-bar-number">{ab.energy}</div>
+                        </div>
+                      </div>
+
+                      <p>사회성</p>
+                      <div className="progress-bar-wrapper">
+                        <div className="progress-bar" style={{ width: `${ab.social * 10}%` }}>
+                          <div className="progress-bar-number">{ab.social}</div>
+                        </div>
+                      </div>
+
+                      <p>대처능력:</p>
+                      <div className="progress-bar-wrapper">
+                        <div className="progress-bar" style={{ width: `${ab.intelligence * 10}%` }}>
+                          <div className="progress-bar-number">{ab.intelligence}</div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
+      {/* <ol className="mbti-list">
         <li className="mbti-item">
           <span>여다희</span>
         </li>
         <li>
           <span>INTP</span>
         </li>
-      </ol>
+      </ol> */}
     </section>
   );
 }

--- a/src/app/(tests)/freetest/[id]/components/MbtiSection/_MbtiSection.scss
+++ b/src/app/(tests)/freetest/[id]/components/MbtiSection/_MbtiSection.scss
@@ -1,9 +1,148 @@
 @import '@/styles/variable';
 @import '@/styles/mixins/flex.scss';
 
-.mbti {
-  .mbti-list {
+.Mbti-cover {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  width: 100%;
+  margin-top: 3rem;
+
+  .swiper {
+    width: 80%; // 기본 너비
+    overflow: hidden;
   }
-  .mbti-item {
+
+  .card-header {
+    width: 100%;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 2rem;
+    color: #3e2500;
+    font-size: 2.4rem;
+    font-weight: 800;
+
+    :nth-child(1) {
+      font-size: 2.8rem;
+      color: #ffa726;
+    }
+
+    .titles {
+      display: flex;
+      gap: 1rem;
+
+      p {
+        font-size: 1.2rem;
+      }
+      :nth-child(1) {
+        color: #fecd5b;
+      }
+    }
+  }
+
+  .mbti-reason {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .swiper-wrapper {
+    display: flex;
+  }
+
+  .swiper-slide {
+    border: 0.2rem solid #fecd5b;
+    border-radius: 2rem;
+    width: 40rem;
+    padding: 2rem;
+    transition: filter 0.3s ease;
+  }
+
+  .swiper-slide:not(.swiper-slide-active) {
+    filter: blur(1px);
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+
+  .swiper-slide-active {
+    filter: blur(0);
+    transform: scale(1);
+  }
+
+  .swiper-pagination {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 2rem;
+  }
+
+  .swiper-pagination-bullet {
+    border-radius: 50%;
+    width: 2rem;
+    height: 2rem;
+    opacity: 0.7;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .swiper-pagination-bullet-active {
+    background: #fecd5b;
+    opacity: 1;
+    color: #222;
+  }
+}
+
+.progress-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  transition: 0.3s ease;
+
+  p {
+    font-size: 1.4rem;
+    font-weight: 400;
+  }
+
+  .progress-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    width: 100%;
+  }
+  .progress-bar-wrapper {
+    width: 100%;
+    background-color: #fff1d2;
+    border-radius: 1rem;
+    height: 1.6rem; // 프로그래스바 높이
+    overflow: hidden;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    .progress-bar {
+      background-color: #ffa726; // 프로그래스바 색상
+      color: #fff;
+      padding: 0.3rem;
+      border-radius: 1rem;
+      font-size: 1rem;
+      white-space: nowrap;
+      overflow: hidden;
+      height: 100%;
+      transition: width 0.5s ease-in-out;
+      position: relative;
+      z-index: 1; // 프로그래스바가 전면에 표시되도록 설정
+
+      .progress-bar-number {
+        display: flex;
+        justify-content: flex-start;
+        margin-left: 0.3rem;
+        align-items: center;
+      }
+    }
   }
 }

--- a/src/app/(tests)/freetest/[id]/components/ShareSection/ShareSection.tsx
+++ b/src/app/(tests)/freetest/[id]/components/ShareSection/ShareSection.tsx
@@ -40,9 +40,11 @@ function ShareSection() {
     <section className="share">
       <h2 className="heading-2">결과 공유하기</h2>
       <p className="heading-desc">대화방 참여자들에게 분석 내용을 공유해 보세요!</p>
-      <Button styleType="tonal" size="md" rounded onClick={handleButtonPress}>
-        공유하기
-      </Button>
+      <div className="cont-btn">
+        <Button styleType="tonal" size="md" rounded onClick={handleButtonPress}>
+          공유하기
+        </Button>
+      </div>
       {isModalOpen && (
         <Modal isOpen={isModalOpen} onClose={closeModal} content="친구들에게 결과를 공유해보세요!">
           <div className="list-btn">

--- a/src/app/(tests)/freetest/[id]/components/ShareSection/_ShareSection.scss
+++ b/src/app/(tests)/freetest/[id]/components/ShareSection/_ShareSection.scss
@@ -8,6 +8,11 @@ section.share {
 
   width: 100%;
   min-height: fit-content;
+
+  .cont-btn {
+    margin-top: 3rem;
+    transform: scale(1.2);
+  }
 }
 
 .list-btn {

--- a/src/app/(tests)/freetest/[id]/components/TopRatedTalkerSection/_TopRatedTalkerSection.scss
+++ b/src/app/(tests)/freetest/[id]/components/TopRatedTalkerSection/_TopRatedTalkerSection.scss
@@ -6,11 +6,18 @@
   justify-content: center;
 
   background-color: #fffaed;
+  h3.heading-3 {
+    margin-top: 8rem;
+  }
 
   &::before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
     content: '';
     margin-bottom: -7rem;
-    height: 16rem;
+    height: 8rem;
     width: 100%;
     display: block;
     background-image: url('/image/wave.svg');

--- a/src/app/(tests)/freetest/[id]/page.tsx
+++ b/src/app/(tests)/freetest/[id]/page.tsx
@@ -2,8 +2,7 @@
 
 import PopularWordSection from './components/PopularWordSection/PopularWordSection';
 import ThemeSection from './components/ThemeSection/ThemeSection';
-import Mbti from '@/components/Mbti/Mbti';
-// import MbtiSection from './components/MbtiSection/MbtiSection';
+import MbtiSection from './components/MbtiSection/MbtiSection';
 import TopRatedTalkerSection from './components/TopRatedTalkerSection/TopRatedTalkerSection';
 import ShareSection from './components/ShareSection/ShareSection';
 import Script from 'next/script';
@@ -96,8 +95,7 @@ export default async function Page({ params }: { params: { id: string } }) {
       ></Script>
       <ThemeSection data={chatThemeData} />
       <TopRatedTalkerSection data={circlePackingData} />
-      {/* <MbtiSection data={[]} /> */}
-      <Mbti extraItem={extraItem} />
+      <MbtiSection data={extraItem.result} />
       <PopularWordSection data={wordCloudData} />
       <ShareSection />
     </article>


### PR DESCRIPTION
closes: #52 

### 📝 개요

- 결과 페이지 스타일링 수정

### 💽 작업 사항
- 결과 페이지 배경 영역 화면을 꽉 채우게 수정
<img width="600" alt="스크린샷 2024-08-19 오후 12 11 14" src="https://github.com/user-attachments/assets/cc613d86-9042-4a62-a7e8-6f677e2f84a3">

