### PR TITLE
[Fix] 결과페이지 fetch를 통해 불러온 데이터로 화면 그리기 #52

### DIFF
--- a/src/app/(tests)/freetest/[id]/components/MbtiSection/MbtiSection.tsx
+++ b/src/app/(tests)/freetest/[id]/components/MbtiSection/MbtiSection.tsx
@@ -23,16 +23,11 @@ interface MbtiAnalysisItem {
 }
 
 interface MbtiSectionPropType {
-  data: {
-    mbti: {
-      analysis: MbtiAnalysisItem[];
-    };
-  };
+  data: MbtiAnalysisItem[];
 }
 
-function MbtiSection({ data }: MbtiSectionPropType) {
-  const { analysis = [] } = data.mbti || [];
-  console.log(analysis);
+function MbtiSection({ data = [] }: MbtiSectionPropType) {
+  console.log(data);
 
   return (
     <section className="mbti">
@@ -63,7 +58,7 @@ function MbtiSection({ data }: MbtiSectionPropType) {
             },
           }}
         >
-          {analysis.map((item, index) => (
+          {data.map((item, index) => (
             <SwiperSlide key={index}>
               <div>
                 <div className="card-header">

--- a/src/app/(tests)/freetest/[id]/components/PopularWordSection/PopularWordSection.tsx
+++ b/src/app/(tests)/freetest/[id]/components/PopularWordSection/PopularWordSection.tsx
@@ -2,20 +2,25 @@ import WordCloud from '@/components/graph/WordCloud';
 import './_PopularWordSection.scss';
 
 interface PopularWordSectionPropType {
-  data: {
-    key: string;
-    value: number;
-  }[];
+  data: { [key: string]: number };
 }
 
-function PopularWordSection({ data = [] }: PopularWordSectionPropType) {
+function PopularWordSection({ data }: PopularWordSectionPropType) {
+  const keys = Object.keys(data);
+  const values = Object.values(data);
+  const parsedData = keys.map((key, index) => ({ key: key, value: values[index] }));
+
   return (
     <section className="most-popular-word">
       <h3 className="heading-3">가장 많이 나온 단어</h3>
       <p className="heading-desc">우리 대화방에서 가장 많이 사용한 단어에요</p>
-      <div className="graph">
-        <WordCloud data={data} />
-      </div>
+      {data ? (
+        <div className="graph">
+          <WordCloud data={parsedData} />
+        </div>
+      ) : (
+        <div>데이터가 없어요</div>
+      )}
     </section>
   );
 }

--- a/src/app/(tests)/freetest/[id]/components/ThemeSection/ThemeSection.tsx
+++ b/src/app/(tests)/freetest/[id]/components/ThemeSection/ThemeSection.tsx
@@ -14,7 +14,7 @@ function ThemeSection({ data }: ThemeSectionPropType) {
       <h3 className="heading-3">대화 주제 TOP3</h3>
       <ul className="bubble-list">
         {data &&
-          data.map(({ title, content }, i) => (
+          data.slice(0, 3).map(({ title, content }, i) => (
             <li className="bubble-item" key={`bubble-${i}`}>
               <p className="bubble-title">{title}</p>
               <p className="bubble-text">{content}</p>

--- a/src/app/(tests)/freetest/[id]/components/TopRatedTalkerSection/TopRatedTalkerSection.tsx
+++ b/src/app/(tests)/freetest/[id]/components/TopRatedTalkerSection/TopRatedTalkerSection.tsx
@@ -3,12 +3,11 @@ import './_TopRatedTalkerSection.scss';
 
 interface TopRatedTalkerSectionPropType {
   data: {
-    key: string;
-    value: number;
-  }[];
+    [key: string]: number;
+  };
 }
 
-function TopRatedTalkerSection({ data = [] }: TopRatedTalkerSectionPropType) {
+function TopRatedTalkerSection({ data }: TopRatedTalkerSectionPropType) {
   const getPercentage = (data: { key: string; value: number }[], value: number) => {
     let sumValue = 0;
     data.forEach((d) => {
@@ -18,21 +17,25 @@ function TopRatedTalkerSection({ data = [] }: TopRatedTalkerSectionPropType) {
     return ((value / sumValue) * 100).toFixed(0);
   };
 
+  const keys = Object.keys(data);
+  const values = Object.values(data);
+  const parsedData = keys.map((key, index) => ({ key: key, value: values[index] }));
+
   return (
     <section className="top-rated-talker">
       <h3 className="heading-3">가장 많이 말한 사람</h3>
       <p className="heading-desc">채팅방 대화 지분 1위</p>
       <div className="graph">
-        <CirclePacking width={400} height={500} data={data} />
+        <CirclePacking width={400} height={500} data={parsedData} />
         <ul className="rank-list">
-          {data
+          {parsedData
             .sort((a, b) => b.value - a.value)
             .map(({ key, value }, index) => (
               <li className="rank-item" key={`rank-${key}-${index}`}>
                 <span className="rank">{index + 1}위</span>
                 <span className="name">{key}</span>
                 <span className="count">{value}회</span>
-                <span className="percentage">{getPercentage(data, value)}%</span>
+                <span className="percentage">{getPercentage(parsedData, value)}%</span>
               </li>
             ))}
         </ul>

--- a/src/app/(tests)/freetest/[id]/page.tsx
+++ b/src/app/(tests)/freetest/[id]/page.tsx
@@ -11,51 +11,36 @@ import './_FreeTestResultPage.scss';
 const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
 const SERVER_URL = process.env.NEXT_PUBLIC_API_SERVER;
 
-// NOTE 채팅 주제 요약 더미데이터
-const chatThemeData = [
-  {
-    title: '대화내역 분석을 주제로 한 대화',
-    content:
-      '하이라이톡을 어떻게 개발할 것인가에 대해 의논했어요. 여다희님이 스타일링이 어렵다고 말하며 UI 개선을 제안하고, 김설하님과 윤우중님이 거부했어요.',
-  },
-  {
-    title: '대화내역 분석을 주제로 한 대화',
-    content:
-      '하이라이톡을 어떻게 개발할 것인가에 대해 의논했어요. 여다희님이 스타일링이 어렵다고 말하며 UI 개선을 제안하고, 김설하님과 윤우중님이 거부했어요.',
-  },
-  {
-    title: '대화내역 분석을 주제로 한 대화',
-    content:
-      '하이라이톡을 어떻게 개발할 것인가에 대해 의논했어요. 여다희님이 스타일링이 어렵다고 말하며 UI 개선을 제안하고, 김설하님과 윤우중님이 거부했어요.',
-  },
-];
+type EmotionType = '기쁨' | '슬픔' | '불안' | '놀람' | '분노';
 
-// NOTE 가장 많이 말한 사람 더미데이터
-const circlePackingData = [
-  { key: '김설하', value: 15 },
-  { key: '윤우중', value: 30 },
-  { key: '여다희', value: 25 },
-  { key: '정길용', value: 10 },
-  { key: '정현주', value: 9 },
-];
+interface FreeTestResultData {
+  topic: { summary: { title: string; content: string }[] };
+  mbti: {
+    analysis: {
+      names: string;
+      value: string;
+      reason: string;
+      ability: { energy: number; social: number; intelligence: number }[];
+      etc: string[];
+    }[];
+  };
+  talkCount: {
+    counts: {
+      [key: string]: number;
+    };
+  };
+  mostWords: {
+    topWords: {
+      [key: string]: number;
+    };
+  };
+  peoples: string[];
+  talkbangEmotion: {
+    [key in EmotionType]: number;
+  };
+}
 
-// NOTE 가장 많이 나온 단어 더미데이터
-const wordCloudData = [
-  { key: '중우', value: 10 },
-  { key: '짱이다', value: 15 },
-  { key: '울랄라', value: 30 },
-  { key: '얍', value: 100 },
-  { key: '응', value: 80 },
-  { key: '바빠', value: 41 },
-  { key: '나가라', value: 10 },
-  { key: '어떻게', value: 20 },
-  { key: '되는거지', value: 10 },
-  { key: '야', value: 40 },
-  { key: '아니야', value: 30 },
-  { key: '덤벼', value: 60 },
-];
-
-export async function getData(id: string) {
+export async function getData(id: string): Promise<FreeTestResultData | null> {
   try {
     const response = await fetch(`${SERVER_URL}/posts/${id}`, {
       headers: {
@@ -68,8 +53,8 @@ export async function getData(id: string) {
       return null;
     }
 
-    const data = await response.json();
-    return data;
+    const result = await response.json();
+    return result.item.extra.result;
   } catch (error) {
     console.error('Error fetching data:', error);
     return null;
@@ -77,11 +62,11 @@ export async function getData(id: string) {
 }
 
 export default async function Page({ params }: { params: { id: string } }) {
-  const item = await getData(params.id);
-  const extraItem = item?.item?.extra;
+  const data = await getData(params.id);
+  const { topic, mbti, talkCount, mostWords } = data!;
 
-  if (!extraItem) {
-    return <div>페이지를 찾을 수 없습니다.</div>;
+  if (!data) {
+    throw new Error('잘못된 접근입니다.');
   }
 
   return (
@@ -93,10 +78,10 @@ export default async function Page({ params }: { params: { id: string } }) {
         crossOrigin="anonymous"
         strategy="afterInteractive"
       ></Script>
-      <ThemeSection data={chatThemeData} />
-      <TopRatedTalkerSection data={circlePackingData} />
-      <MbtiSection data={extraItem.result} />
-      <PopularWordSection data={wordCloudData} />
+      <ThemeSection data={topic.summary} />
+      <TopRatedTalkerSection data={talkCount.counts} />
+      <MbtiSection data={mbti.analysis} />
+      <PopularWordSection data={mostWords.topWords} />
       <ShareSection />
     </article>
   );


### PR DESCRIPTION
closes: #52 

### 📝 개요

- fetch를 통해 불러온 데이터로 화면 그리기

### 💽 작업 사항

- freetest Data fetching 반환 데이터 변경
- 데이터 props 전달받는 컴포넌트 수정

### 추가 전달사항

아래 라우트에서 테스트 가능합니다.
/freetest/45
/freetest/46