### PR TITLE
[Fix] 결과 보관함 데이터 Fetching 오류 수정 및 데이터타입 지정 #85

### DIFF
--- a/src/app/(user)/mypage/archive/components/Card/Card.tsx
+++ b/src/app/(user)/mypage/archive/components/Card/Card.tsx
@@ -12,7 +12,6 @@ interface CardPropType {
   username: string;
   createdAt: string;
   isMine: boolean;
-  peoples: string[];
 }
 
 function Card({
@@ -22,7 +21,6 @@ function Card({
   username = '',
   createdAt,
   isMine = false,
-  peoples = [],
 }: CardPropType) {
   const [isEditing, setIsEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/app/(user)/mypage/archive/components/CategoryList/CategoryList.tsx
+++ b/src/app/(user)/mypage/archive/components/CategoryList/CategoryList.tsx
@@ -15,7 +15,7 @@ function CategoryList() {
   return (
     <ul className="list-categories">
       {categories.map((name, index) => (
-        <li>
+        <li key={name}>
           <Button
             theme="black"
             styleType={index === focusedIndex ? 'default' : 'tonal'}

--- a/src/app/(user)/mypage/archive/page.tsx
+++ b/src/app/(user)/mypage/archive/page.tsx
@@ -1,72 +1,27 @@
 import './_ArchivePage.scss';
 import { auth } from '@/auth';
+import { getArchiveData } from '@/serverActions/archiveAction';
 import CategoryList from './components/CategoryList/CategoryList';
 import Card from './components/Card/Card';
 import NoDataNotification from './components/NoDataNotification/NoDataNotification';
-
-const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
-const SERVER_URL = process.env.NEXT_PUBLIC_API_SERVER;
-
-interface Post {
-  _id: number;
-  title: string;
-  extra: {
-    result: {
-      peoples: string[];
-    };
-  };
-  user: {
-    _id: number;
-    name: string;
-  };
-  createdAt: string;
-  type: string;
-}
-
-const getData = async (accessToken: string) => {
-  try {
-    const URL = `${SERVER_URL}/posts/users`;
-    const config = {
-      headers: {
-        'Content-Type': 'application/json',
-        'client-id': `${CLIENT_ID}`,
-        authorization: `Bearer ${accessToken}`,
-      },
-    };
-
-    const response = await fetch(URL, config);
-    if (!response.ok) {
-      throw new Error();
-    }
-
-    const data = await response.json();
-    if (data.ok === 1) {
-      return data.item as Post[];
-    } else {
-      throw new Error(data.message);
-    }
-  } catch (error) {
-    console.error('Error fetching data:', error);
-    return null;
-  }
-};
+import { PostItem } from '@/types';
 
 async function ArchivePage() {
   const userAuth = await auth();
-  const fetchedData = userAuth ? await getData(userAuth.accessToken) : [];
+  const fetchedData = userAuth ? await getArchiveData() : [];
 
+  // console.log(userAuth);
   return (
     <>
       <h1 className="heading">내 분석 보관함</h1>
       <CategoryList />
       {fetchedData && fetchedData.length > 0 ? (
         <ul className="list-data">
-          {fetchedData.map((item) => (
-            <li className="item-data">
+          {fetchedData.map((item: PostItem) => (
+            <li className="item-data" key={item?._id}>
               <Card
                 {...item}
                 username={item?.user?.name}
-                peoples={item?.extra?.result?.peoples}
                 isMine={
                   userAuth?.user ? Number(userAuth.user.id) === Number(item?.user._id) : false
                 }

--- a/src/data/freetest.json
+++ b/src/data/freetest.json
@@ -1,0 +1,84 @@
+{
+  "ok": 1,
+  "item": {
+    "_id": 22,
+    "extra": {
+      "result": {
+        "topic": {
+          "summary": [
+            {
+              "title": "면접 준비와 스트레스",
+              "content": "여다희가 면접 준비에 대한 스트레스를 이야기하며, 친구들에게 조언을 구하고 있다."
+            },
+            {
+              "title": "고등어조림과 식사 계획",
+              "content": "여다희가 면접 후 고등어조림을 먹으러 가기로 계획하고, 친구들이 응원해준다."
+            },
+            {
+              "title": "연락과 관계에 대한 고민",
+              "content": "여다희가 전썸남과의 연락 문제에 대해 이야기하며, 친구들이 조언을 해준다."
+            }
+          ]
+        },
+        "mbti": {
+          "analysis": [
+            {
+              "names": "여다희",
+              "value": "ENFP",
+              "reason": "여다희는 감정 표현이 풍부하고, 친구들과의 소통을 중요시하는 모습을 보인다.",
+              "ability": [{ "energy": 8, "social": 9, "intelligence": 7 }],
+              "etc": ["열정적인 친구", "사교적인 성격"]
+            },
+            {
+              "names": "배지",
+              "value": "ESFJ",
+              "reason": "배지는 친구들을 잘 챙기고, 긍정적인 에너지를 주는 모습이 보인다.",
+              "ability": [{ "energy": 7, "social": 8, "intelligence": 6 }],
+              "etc": ["사교적인 리더", "친절한 성격"]
+            },
+            {
+              "names": "정감자",
+              "value": "INFP",
+              "reason": "정감자는 감정적으로 깊이 있는 대화를 나누며, 친구들의 고민에 공감하는 모습을 보인다.",
+              "ability": [{ "energy": 6, "social": 7, "intelligence": 8 }],
+              "etc": ["사색가", "감성적인 친구"]
+            },
+            {
+              "names": "박수",
+              "value": "ENTP",
+              "reason": "박수는 유머러스하고, 친구들과의 대화에서 창의적인 아이디어를 제시하는 모습을 보인다.",
+              "ability": [{ "energy": 9, "social": 8, "intelligence": 9 }],
+              "etc": ["창의적인 발명가", "재치 있는 친구"]
+            }
+          ]
+        },
+        "talkCount": { "counts": { "여다희": 45, "배지": 38, "정감자": 30, "박수": 25 } },
+        "mostWords": {
+          "topWords": {
+            "면접": 15,
+            "고등어조림": 10,
+            "스트레스": 8,
+            "연락": 7,
+            "친구": 12,
+            "사진": 9,
+            "맛집": 6,
+            "고민": 11,
+            "응원": 5,
+            "사랑": 4
+          }
+        },
+        "peoples": ["여다희", "배지", "정감자", "박수"],
+        "talkbangEmotion": { "기쁨": 20, "슬픔": 5, "불안": 15, "놀람": 3, "분노": 2 }
+      }
+    },
+    "title": "여다희님 외 3명의 대화",
+    "type": "lovetest",
+    "views": 1,
+    "user": { "_id": 1, "name": "티머치토커", "image": "/files/08-highlightalk/highlightalk.png" },
+    "createdAt": "2024.08.22 15:07:16",
+    "updatedAt": "2024.08.22 15:07:16",
+    "seller_id": null,
+    "product": { "name": [], "mainImages": [] },
+    "bookmarks": 0
+  }
+}

--- a/src/data/lovetest.json
+++ b/src/data/lovetest.json
@@ -1,0 +1,69 @@
+{
+  "_id": 11,
+  "extra": {
+    "result": {
+      "relationshipAnalysis": {
+        "summary": "이소정과 윤우중은 서로의 일상과 관심사에 대해 활발하게 소통하며, 서로의 고민을 나누고 지원하는 관계입니다. 이소정은 윤우중에게 여러 가지 제안과 격려를 하며, 윤우중은 이소정의 의견을 존중하고 함께 고민하는 모습을 보입니다. 두 사람은 서로의 스터디와 취업 준비에 대해 이야기하며, 함께 공부하고 싶어하는 의사를 표현합니다. 이들은 서로의 존재를 소중히 여기고 있으며, 자주 연락을 주고받는 모습에서 친밀감을 느낄 수 있습니다. 또한, 서로의 재정적인 거래를 통해 신뢰를 쌓고 있습니다. 이들의 대화는 유머와 친근함이 가득하며, 서로의 일상에 관심을 가지고 있다는 점에서 긍정적인 관계로 보입니다.",
+        "analysis": [
+          {
+            "names": "이소정, 윤우중",
+            "compatibilityScore": 85,
+            "reason": "서로의 일상과 고민을 공유하며, 서로를 지지하는 모습이 보이기 때문에 높은 궁합 점수를 부여했습니다.",
+            "relationshipProbability": {
+              "becomeCouple": 70,
+              "marriageProbability": 50
+            },
+            "etc": [
+              "title: '서로를 지지하는 파트너'",
+              "서로의 일상에 관심을 가지며, 함께 시간을 보내고 싶어하는 모습이 인상적입니다."
+            ],
+            "betterLover": {
+              "이소정": 60,
+              "윤우중": 40
+            },
+            "personalFactors": {
+              "money": 70,
+              "health": 80,
+              "love": 90,
+              "daily": 85
+            }
+          }
+        ]
+      },
+      "interestedAbout": [
+        {
+          "person": "이소정",
+          "interests": {
+            "happy": 80,
+            "unrest": 20,
+            "trust": 90,
+            "love": 85,
+            "stress": 30,
+            "interested": 75
+          }
+        },
+        {
+          "person": "윤우중",
+          "interests": {
+            "happy": 75,
+            "unrest": 25,
+            "trust": 85,
+            "love": 80,
+            "stress": 35,
+            "interested": 70
+          }
+        }
+      ]
+    }
+  },
+  "views": 2,
+  "user": {
+    "_id": 5,
+    "name": "우중",
+    "image": null
+  },
+  "type": "post",
+  "createdAt": "2024.08.22 12:16:46",
+  "updatedAt": "2024.08.22 12:16:46",
+  "seller_id": null
+}

--- a/src/serverActions/archiveAction.ts
+++ b/src/serverActions/archiveAction.ts
@@ -1,0 +1,58 @@
+import { auth } from '@/auth';
+
+const API_SERVER = process.env.NEXT_PUBLIC_API_SERVER;
+const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID;
+
+export const getArchiveData = async () => {
+  'use server';
+
+  const testTypes = ['lovetest', 'freetest'];
+  const session = await auth();
+  const URL = `${API_SERVER}/posts/users`;
+
+  try {
+    // 각 testType에 대해 fetch 요청을 Promise로 생성
+    const fetchPromises = testTypes.map(async (type) => {
+      try {
+        const response = await fetch(`${URL}?type=${type}`, {
+          headers: {
+            'Content-Type': 'application/json',
+            'client-id': `${CLIENT_ID}`,
+            Authorization: `Bearer ${session?.accessToken}`,
+          },
+        });
+        const data = await response.json();
+
+        console.log('archive: ', data);
+        if (data.ok === 1) {
+          return data.item; // 성공적으로 가져온 데이터를 반환
+        } else {
+          console.log(data.message);
+          return []; // 에러 메시지가 있을 경우 빈 배열 반환
+        }
+      } catch (error) {
+        console.log(error);
+        throw new Error('Error fetching data - ' + type);
+      }
+    });
+
+    // 모든 Promise가 완료될 때까지 기다림
+    const results = await Promise.all(fetchPromises);
+
+    // 결과 평탄화, 하나의 배열로 만들기
+    const flattenedResults = results.flat();
+
+    // 날짜 기준으로 정렬
+    flattenedResults.sort((a, b) => {
+      const D1 = new Date(a.createdAt);
+      const D2 = new Date(b.createdAt);
+      return D1 > D2 ? 1 : -1;
+    });
+
+    console.log('flattenedResults: ' + flattenedResults);
+    return flattenedResults;
+  } catch (error) {
+    console.error(error);
+    throw new Error('Error fetching data');
+  }
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './user';
+export * from './posts';

--- a/src/types/posts.ts
+++ b/src/types/posts.ts
@@ -1,3 +1,5 @@
+import { FreeTestData, LoveTestData } from './test';
+
 export interface User {
   _id: number;
   name: string;
@@ -17,16 +19,17 @@ export interface PostItem {
   type: string;
   title: string;
   content: string;
-  image: string;
+  image?: string;
   views: number;
   user: User;
   replies: string;
   createdAt: string;
   updatedAt: string;
-  seller_id: number | null;
-  repliesCount: number;
-  product: Product;
-  pagination: pagination;
+  extra?: LoveTestData | FreeTestData;
+  seller_id?: number | null;
+  repliesCount?: number;
+  product?: Product;
+  pagination?: pagination;
 }
 
 export interface Reply {

--- a/src/types/test.ts
+++ b/src/types/test.ts
@@ -1,0 +1,60 @@
+type ChatThemeType = 'money' | 'health' | 'love' | 'daily';
+type LoveEmotionType = 'happy' | 'unrest' | 'trust' | 'love' | 'stress' | 'interested';
+
+export interface LoveTestData {
+  relationshipAnalysis: {
+    summary: string;
+    analysis: {
+      names: string;
+      compatibilityScore: number;
+      reason: string;
+      relationshipProbability: {
+        becomeCouple: number;
+        marriageProbability: number;
+      };
+      etc: string[];
+      betterLover: {
+        [key: string]: number;
+      };
+      personalFactors: {
+        [key in ChatThemeType]: number;
+      };
+    }[];
+  };
+
+  interestedAbout: {
+    person: string;
+    interests: {
+      [key in LoveEmotionType]: number;
+    };
+  }[];
+}
+
+type EmotionType = '기쁨' | '슬픔' | '불안' | '놀람' | '분노';
+
+export interface FreeTestData {
+  topic: { summary: { title: string; content: string }[] };
+  mbti: {
+    analysis: {
+      names: string;
+      value: string;
+      reason: string;
+      ability: { energy: number; social: number; intelligence: number }[];
+      etc: string[];
+    }[];
+  };
+  talkCount: {
+    counts: {
+      [key: string]: number;
+    };
+  };
+  mostWords: {
+    topWords: {
+      [key: string]: number;
+    };
+  };
+  peoples: string[];
+  talkbangEmotion: {
+    [key in EmotionType]: number;
+  };
+}


### PR DESCRIPTION
closes: #85 

### 📝 개요

- "내 분석 보관함" 페이지(/mypage/archive)에서 결과가 불러와지지 않는 문제를 해결했습니다. 
- 내가 작성한 글을 불러오는 API의 type 쿼리 기본값이 "post"였는데, 이전에는 테스트 결과들이 "type=post"였어서 문제가 발생하지 않았다가 현재 분석 결과물에 `type`이 "lovetest", "freetest" 등으로 별도 지정되면서 문제가 발생한 것으로 보입니다.
- 이에 따라 "lovetest", "freetest" 등 분석 결과 `type`을 각각 쿼리로 지정해 fetching 해오는 방식으로 문제를 해결하였습니다. 각각 불러온 데이터는 `createdAt` 필드를 기준으로 정렬됩니다.

### 💽 작업 사항

- 결과 보관함 데이터 Fetching 오류 해결